### PR TITLE
Add Clerk role claims and auth pages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 # Clerk Authentication
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_xxxxxx
 CLERK_SECRET_KEY=sk_test_xxxxxx
+# Clerk JWT Template used to include the `role` claim
+CLERK_JWT_TEMPLATE_NAME=payroll
 
 # Supabase
 NEXT_PUBLIC_SUPABASE_URL=your_project_url

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Before you begin, ensure you have the following:
 2. Create a new application
 3. Go to API Keys
 4. Copy the `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` and `CLERK_SECRET_KEY`
+5. Create a JWT template in Clerk that exposes `role` from `publicMetadata`
+6. Set `CLERK_JWT_TEMPLATE_NAME` to the name of that template
 
 ### Supabase Setup
 1. Go to [Supabase Dashboard](https://app.supabase.com/)
@@ -79,6 +81,7 @@ Create a `.env` file in the root directory with the following variables:
 # Clerk Authentication
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=your_publishable_key
 CLERK_SECRET_KEY=your_secret_key
+CLERK_JWT_TEMPLATE_NAME=payroll
 
 # Supabase
 NEXT_PUBLIC_SUPABASE_URL=your_supabase_url

--- a/app/(auth)/sign-in/page.tsx
+++ b/app/(auth)/sign-in/page.tsx
@@ -1,0 +1,9 @@
+import { SignIn } from '@clerk/nextjs'
+
+export default function SignInPage() {
+  return (
+    <div className="flex justify-center pt-20">
+      <SignIn path="/app/(auth)/sign-in" signUpUrl="/app/(auth)/sign-up" />
+    </div>
+  )
+}

--- a/app/(auth)/sign-up/page.tsx
+++ b/app/(auth)/sign-up/page.tsx
@@ -1,0 +1,42 @@
+import { clerkClient } from '@clerk/nextjs/server'
+
+export default function SignUpPage() {
+  async function createUser(formData: FormData) {
+    'use server'
+    const email = String(formData.get('email'))
+    const password = String(formData.get('password'))
+    const role = String(formData.get('role')) as 'accountant' | 'staff'
+
+    await clerkClient.users.createUser({
+      emailAddress: [email],
+      password,
+      publicMetadata: { role },
+    })
+  }
+
+  return (
+    <form action={createUser} className="mx-auto mt-10 flex w-80 flex-col gap-4">
+      <input
+        type="email"
+        name="email"
+        placeholder="Email"
+        required
+        className="rounded border p-2"
+      />
+      <input
+        type="password"
+        name="password"
+        placeholder="Password"
+        required
+        className="rounded border p-2"
+      />
+      <select name="role" className="rounded border p-2">
+        <option value="staff">Staff</option>
+        <option value="accountant">Accountant</option>
+      </select>
+      <button type="submit" className="rounded bg-black p-2 text-white">
+        Create user
+      </button>
+    </form>
+  )
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,27 @@
+import { auth } from '@clerk/nextjs/server'
+import { useAuth } from '@clerk/nextjs'
+
+export type UserRole = 'accountant' | 'staff'
+
+/**
+ * Get the current user's role on the server.
+ */
+export function getServerUserRole(): UserRole | undefined {
+  const { sessionClaims } = auth()
+  return sessionClaims?.role as UserRole | undefined
+}
+
+/**
+ * React hook to read the role claim on the client.
+ */
+export function useUserRole(): UserRole | undefined {
+  const { sessionClaims } = useAuth()
+  return sessionClaims?.role as UserRole | undefined
+}
+
+/**
+ * Helper to check if the current user matches a role.
+ */
+export function hasServerRole(role: UserRole): boolean {
+  return getServerUserRole() === role
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,25 +1,13 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server"
-import { NextRequest, NextResponse } from "next/server"
 
-// Default Next.js middleware to allow all requests
-export function middleware(request: NextRequest) {
-  return NextResponse.next()
-}
+const isProtectedRoute = createRouteMatcher(['/app(.*)'])
+const isAuthRoute = createRouteMatcher(['/app/(auth)(.*)'])
 
-/**
- * Uncomment the following code to enable authentication with Clerk
- */
-
-// const isProtectedRoute = createRouteMatcher(['/protected'])
-
-// export default clerkMiddleware(async (auth, req) => {
-//     if (isProtectedRoute(req)) {
-//       // Handle protected routes check here
-//       return NextResponse.redirect(req.nextUrl.origin)
-//     }
-
-//     return NextResponse.next()
-// })  
+export default clerkMiddleware((auth, req) => {
+  if (isProtectedRoute(req) && !isAuthRoute(req)) {
+    auth().protect()
+  }
+})
 
 export const config = {
   matcher: [


### PR DESCRIPTION
## Summary
- configure Clerk JWT template in `.env.example`
- document role-based JWT setup in README
- add helpers in `lib/auth.ts`
- enable Clerk middleware for `/app` routes
- add sign-in and admin sign-up pages with role selection

## Testing
- `npm run lint` *(fails: next not found)*