### PR TITLE
Add Clerk role claims and auth pages

### DIFF
--- a/app/(auth)/sign-up/page.tsx
+++ b/app/(auth)/sign-up/page.tsx
@@ -1,8 +1,10 @@
-import { clerkClient } from '@clerk/nextjs/server'
+import { redirect } from 'next/navigation'
 
 export default function SignUpPage() {
   async function createUser(formData: FormData) {
     'use server'
+    const { clerkClient } = await import('@clerk/nextjs/server')
+
     const email = String(formData.get('email'))
     const password = String(formData.get('password'))
     const role = String(formData.get('role')) as 'accountant' | 'staff'
@@ -12,6 +14,8 @@ export default function SignUpPage() {
       password,
       publicMetadata: { role },
     })
+
+    redirect('/app/(auth)/sign-in')
   }
 
   return (


### PR DESCRIPTION
## Summary
- configure Clerk JWT template in `.env.example`
- document role-based JWT setup in README
- add helpers in `lib/auth.ts`
- enable Clerk middleware for `/app` routes
- add sign-in and admin sign-up pages with role selection
- dynamically import `clerkClient` in sign-up action

## Testing
- `npm run lint` *(fails: next not found)*