### PR TITLE
Implement timesheet import

### DIFF
--- a/app/accountant/cycle/[month]/page.tsx
+++ b/app/accountant/cycle/[month]/page.tsx
@@ -1,0 +1,40 @@
+'use client'
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+
+export default function CyclePage({ params }: { params: { month: string } }) {
+  const [file, setFile] = useState<File | null>(null)
+  const router = useRouter()
+
+  async function handleImport(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    const data = new FormData()
+    if (file) data.append('file', file)
+    data.append('month', params.month)
+    await fetch('/app/api/cycle/import-timesheet', {
+      method: 'POST',
+      body: data,
+    })
+    router.refresh()
+  }
+
+  async function handleClone() {
+    const data = new FormData()
+    data.append('month', params.month)
+    await fetch('/app/api/cycle/import-timesheet', {
+      method: 'POST',
+      body: data,
+    })
+    router.refresh()
+  }
+
+  return (
+    <div className="p-4">
+      <form onSubmit={handleImport} className="mb-4 flex gap-2">
+        <input type="file" accept=".csv" onChange={(e) => setFile(e.target.files?.[0] || null)} />
+        <button type="submit" className="rounded bg-black px-3 py-1 text-white">Import CSV</button>
+      </form>
+      <button onClick={handleClone} className="rounded bg-gray-300 px-3 py-1">Clone Last Month</button>
+    </div>
+  )
+}

--- a/app/api/cycle/import-timesheet/route.ts
+++ b/app/api/cycle/import-timesheet/route.ts
@@ -1,0 +1,56 @@
+import { supabaseAdmin } from '@/utils/supabase/admin'
+import { NextResponse } from 'next/server'
+
+function parseCsv(text: string) {
+  const lines = text.trim().split(/\r?\n/)
+  const rows = lines.slice(1)
+  return rows.map((line) => {
+    const [user_id, entry_date, hours] = line.split(',')
+    return { user_id, entry_date, hours: hours ? Number(hours) : null }
+  })
+}
+
+export async function POST(req: Request) {
+  const formData = await req.formData()
+  const month = String(formData.get('month'))
+  if (!month) {
+    return NextResponse.json({ error: 'month required' }, { status: 400 })
+  }
+  const file = formData.get('file') as File | null
+
+  let entries: { user_id: string; entry_date: string; hours: number | null }[] = []
+
+  if (file) {
+    const text = await file.text()
+    entries = parseCsv(text)
+  } else {
+    const prev = new Date(`${month}-01`)
+    prev.setMonth(prev.getMonth() - 1)
+    const { data: prevCycle } = await supabaseAdmin
+      .from('payroll_cycles')
+      .select('id')
+      .eq('month', prev.toISOString().slice(0, 10))
+      .single()
+    if (prevCycle) {
+      const { data: prevEntries } = await supabaseAdmin
+        .from('timesheet_entries')
+        .select('user_id,entry_date,hours')
+        .eq('cycle_id', prevCycle.id)
+      entries = prevEntries || []
+    }
+  }
+
+  const { data: cycle } = await supabaseAdmin
+    .from('payroll_cycles')
+    .insert({ month })
+    .select()
+    .single()
+
+  if (cycle && entries.length > 0) {
+    await supabaseAdmin
+      .from('timesheet_entries')
+      .insert(entries.map((e) => ({ ...e, cycle_id: cycle.id })))
+  }
+
+  return NextResponse.json({ id: cycle?.id })
+}

--- a/supabase/migrations/20250125130000_payroll.sql
+++ b/supabase/migrations/20250125130000_payroll.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS payroll_cycles (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    month date NOT NULL UNIQUE,
+    status text NOT NULL DEFAULT 'DRAFT'
+);
+
+CREATE TABLE IF NOT EXISTS timesheet_entries (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    cycle_id uuid REFERENCES payroll_cycles(id) ON DELETE CASCADE,
+    user_id text NOT NULL,
+    entry_date date NOT NULL,
+    hours numeric,
+    created_at timestamp with time zone DEFAULT now()
+);

--- a/types/database.types.ts
+++ b/types/database.types.ts
@@ -34,7 +34,49 @@ export type Database = {
     }
     public: {
         Tables: {
-            [_ in never]: never
+            payroll_cycles: {
+                Row: {
+                    id: string
+                    month: string
+                    status: string
+                }
+                Insert: {
+                    id?: string
+                    month: string
+                    status?: string
+                }
+                Update: {
+                    id?: string
+                    month?: string
+                    status?: string
+                }
+            }
+            timesheet_entries: {
+                Row: {
+                    id: string
+                    cycle_id: string
+                    user_id: string
+                    entry_date: string
+                    hours: number | null
+                    created_at: string
+                }
+                Insert: {
+                    id?: string
+                    cycle_id: string
+                    user_id: string
+                    entry_date: string
+                    hours?: number | null
+                    created_at?: string
+                }
+                Update: {
+                    id?: string
+                    cycle_id?: string
+                    user_id?: string
+                    entry_date?: string
+                    hours?: number | null
+                    created_at?: string
+                }
+            }
         }
         Views: {
             [_ in never]: never


### PR DESCRIPTION
## Summary
- add Supabase tables for payroll cycles and timesheet entries
- implement `/api/cycle/import-timesheet` route for CSV import/clone
- add accountant page to trigger import or clone
- add migration for new tables

## Testing
- `npm run lint` *(fails: next not found)*