### PR TITLE
Move timesheet CSV parsing to helper

### DIFF
--- a/app/api/cycle/import-timesheet/route.ts
+++ b/app/api/cycle/import-timesheet/route.ts
@@ -1,75 +1,7 @@
 import { supabaseAdmin } from '@/utils/supabase/admin'
 import { NextResponse } from 'next/server'
 import axios from 'axios'
-
-// Robust CSV parser for quoted/multiline fields
-function parseCsv(text: string) {
-  const rows = []
-  let current = ''
-  let inQuotes = false
-  let lines = text.split(/\r?\n/)
-  for (let i = 0; i < lines.length; i++) {
-    let line = lines[i]
-    if (inQuotes) {
-      current += '\n' + line
-      if (line.endsWith('"')) {
-        inQuotes = false
-        rows.push(current)
-        current = ''
-      }
-    } else {
-      if ((line.match(/\"/g) || []).length % 2 === 1) {
-        inQuotes = true
-        current = line
-      } else {
-        rows.push(line)
-      }
-    }
-  }
-  if (current) rows.push(current)
-  const headers = rows[0].split(',').map((h) => h.trim().replace(/^"|"$/g, ''))
-  return rows.slice(1).map((row) => {
-    const values = []
-    let val = ''
-    let inside = false
-    for (let i = 0; i < row.length; i++) {
-      const char = row[i]
-      if (char === '"') {
-        inside = !inside
-      } else if (char === ',' && !inside) {
-        values.push(val)
-        val = ''
-      } else {
-        val += char
-      }
-    }
-    values.push(val)
-    const record = {}
-    headers.forEach((header, idx) => {
-      let value = values[idx]?.trim().replace(/^"|"$/g, '')
-      if (
-        [
-          'total_leave_days',
-          'salary',
-          'total_working_days_in_month',
-          'paid_leave_days',
-          'unpaid_leave_days',
-          'actual_working_days',
-          'parking_allowance',
-          'employee_social_insurance_contribution',
-          'salary_advance_deduction',
-          'tuition_fee_deduction_for_children',
-          'employer_social_insurance_contribution',
-          'hours',
-        ].includes(header)
-      ) {
-        value = value ? Number(value.replace(/,/g, '')) : null
-      }
-      record[header] = value
-    })
-    return record
-  })
-}
+import { parseCsv } from '@/lib/parseCsv'
 
 export async function POST(req: Request) {
   const formData = await req.formData()

--- a/lib/parseCsv.ts
+++ b/lib/parseCsv.ts
@@ -1,0 +1,34 @@
+import { parse } from 'csv-parse/sync'
+
+const numericFields = [
+  'total_leave_days',
+  'salary',
+  'total_working_days_in_month',
+  'paid_leave_days',
+  'unpaid_leave_days',
+  'actual_working_days',
+  'parking_allowance',
+  'employee_social_insurance_contribution',
+  'salary_advance_deduction',
+  'tuition_fee_deduction_for_children',
+  'employer_social_insurance_contribution',
+  'hours',
+]
+
+export interface CsvRecord {
+  [key: string]: string | number | null
+}
+
+export function parseCsv(text: string): CsvRecord[] {
+  const records = parse(text, { columns: true, skip_empty_lines: true, trim: true }) as CsvRecord[]
+
+  return records.map((record) => {
+    for (const field of numericFields) {
+      if (record[field] !== undefined) {
+        const value = String(record[field])
+        record[field] = value ? Number(value.replace(/,/g, '')) : null
+      }
+    }
+    return record
+  })
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.0.0",
+        "csv-parse": "^5.5.0",
         "date-fns": "^3.6.0",
         "embla-carousel-react": "^8.5.2",
         "framer-motion": "^12.0.5",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.0.0",
+    "csv-parse": "^5.5.0",
     "date-fns": "^3.6.0",
     "embla-carousel-react": "^8.5.2",
     "framer-motion": "^12.0.5",


### PR DESCRIPTION
## Summary
- add `csv-parse` dependency
- move CSV parsing logic to `lib/parseCsv.ts`
- use the helper in the import timesheet API

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683b1eeeef348320bc8a6f03223fbb1f